### PR TITLE
Implemented the offline stickyNote Sync

### DIFF
--- a/Backend/Routes/notes.js
+++ b/Backend/Routes/notes.js
@@ -34,11 +34,11 @@ async function getNoteAndRole(noteId, userId) {
   };
 }
 
-//Helper Function 2: UpdateNoteVersions
+//Helper Function 2: updateNoteVersions
 //This Function sets the notes currentVersionId to a target Version.
 //It also emits a real time socket event ('note_content_preview') to update the frontend view for all users in the course.
 
-async function UpdateNoteVersion(noteId, content, versionId, userId) {
+async function updateNoteVersion(noteId, content, versionId, userId) {
   await prisma.stickyNotes.update({
     where: {id: noteId},
     data:{
@@ -153,7 +153,7 @@ router.post("/:noteId/undo", verifySession, async (req, res) => {
       targetVersion = prev;
     }
     //update pointer and emit new content preview
-    await UpdateNoteVersion(noteId, targetVersion.content, targetVersion.id, userId);
+    await updateNoteVersion(noteId, targetVersion.content, targetVersion.id, userId);
     res.status(200).json({noteId, content: targetVersion.content})
   } catch (error) {
     res.status(500).json({ error: "Failed to undo" });
@@ -198,7 +198,7 @@ router.post("/:noteId/redo", verifySession, async (req, res) => {
       var nextVersion = versions[currentIndex + 1];
     }
 
-    await UpdateNoteVersion(noteId, nextVersion.content, nextVersion.id, userId);
+    await updateNoteVersion(noteId, nextVersion.content, nextVersion.id, userId);
     res.status(200).json({ noteId, content: nextVersion.content });
   } catch (error) {
     res.status(500).json({ error: "Failed to redo" });

--- a/Frontend/src/context/NetworkStatusContext.jsx
+++ b/Frontend/src/context/NetworkStatusContext.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useEffect, useState } from "react";
+//Create a context to provide network status across the app
+const NetworkStatusContext = createContext();
+//Provider component to wrap components that need network status info
+const NetworkStatusProvider = ({ children }) => {
+  //Set initial network status using navigator.onLine property
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  //UseEffect to setup event listeners once when component mounts
+  useEffect(() => {
+    //Handler: When the browser is online, set isOnline to true
+    const handleOnline = () => {
+      setIsOnline(true); //Update state
+    };
+    //Handler: When the browser is offline, set isOnline to false
+    const handleOffline = () => {
+      setIsOnline(false); //Update state
+    };
+    //Attach event listeners for online/offline events
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    //Cleanup function to remove event listeners on unmount
+    return () => {
+      //Remove event listeners
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+  //Provide the current online status to all child components
+  return (
+    <NetworkStatusContext.Provider value={{ isOnline }}>
+      {children}
+    </NetworkStatusContext.Provider>
+  );
+};
+//Export the context and provider
+export { NetworkStatusContext, NetworkStatusProvider };

--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.jsx";
+import { NetworkStatusProvider } from "./context/NetworkStatusContext.jsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <NetworkStatusProvider>
+      <App />
+    </NetworkStatusProvider>
+  </StrictMode>
+);

--- a/Frontend/src/utils/noteCache.js
+++ b/Frontend/src/utils/noteCache.js
@@ -1,0 +1,43 @@
+//Save a note to local storage using the noteId as the key
+function saveNoteLocally(noteId, noteData) {
+  //Retrive all exisiting notes from local storage or default to empty object
+  const notes = JSON.parse(localStorage.getItem("offlineNotes") || "{}");
+  //Add or update the current note
+  notes[noteId] = noteData;
+  //Save the updated notes back to local storage
+  localStorage.setItem("offlineNotes", JSON.stringify(notes));
+}
+// Retrive a single note from local storage using the noteId as the key
+function getLocalNote(noteId) {
+  try {
+    //Get the full offlineNotes as string from local storage
+    const stored = localStorage.getItem("offlineNotes");
+    //if nothing is stored, return null
+    if (!stored) return null;
+    //Parse the string into an object
+    const allNotes = JSON.parse(stored);
+    //Return the requested note or null if it doesn't exist
+    return allNotes[noteId] || null;
+  } catch (err) {
+    //Log error if JSON parsing fails or storage is corrupted
+    console.error("failed to get local note", err);
+    return null;
+  }
+}
+//Delete a specific note from local storage
+function deleteLocalNote(noteId) {
+  //Parse the existing notes object, defaulting to an empty object
+  const notes = JSON.parse(localStorage.getItem("offlineNotes") || "{}");
+  //Delete the requested note with specified noteId
+  delete notes[noteId];
+  //Save the updated notes back to local storage
+  localStorage.setItem("offlineNotes", JSON.stringify(notes));
+}
+//Get all locally stored notes as an object
+function getAllLocalNotes() {
+  //Parse the notes object or deault to empty if not present
+  const notes = JSON.parse(localStorage.getItem("offlineNotes") || "{}");
+  return notes;
+}
+//export all utility functions for use in other files
+export { saveNoteLocally, getLocalNote, deleteLocalNote, getAllLocalNotes };


### PR DESCRIPTION
## Implementation
- Implemented the offline sticky note editing by storing content and version history in localStorage. 
- Created inline helper functions like mergeNoteWithOffline and SyncOfflineNotes for modular logic inside StickyNoteRoom.jsx
- Track the undo/redo using noteIndex and noteHistory supporting full offline version navigation. 
-  Synced Offline edits to the server on reconnect using handleBlur triggered by NetworkStatusContext. 
- Implemented previous feedback by making helper functions for modularity and comments for readability. 
## Resources
- [Navigator: onLine property](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine)
- [Object in JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries)
## Test Plan
- Made a demo to show how it works offline and syncs online
- https://www.loom.com/share/9c8bfd1ee55849b6abc5d105252cc08a