### PR TITLE
Implemented the enable/disable on the redo and undo in real time

### DIFF
--- a/Frontend/src/utils/noteSocket.js
+++ b/Frontend/src/utils/noteSocket.js
@@ -65,6 +65,12 @@ function onNoteUnlocked(callback) {
 function onLockDenied(callback) {
   socket.on("lock_denied", callback);
 };
+//When the undo/redo state of a note is updated
+function onUndoRedoState(callback) {
+  socket.on("note_undo_redo_state", ({ noteId, userId, canUndo, canRedo }) => {
+    callback({ noteId, userId, canUndo, canRedo });
+  });
+}
 // Off Events
 //Use these functions to prevent memory leaks or repeating events when navigating pages.
 //Stop listening to newNote events
@@ -111,4 +117,5 @@ export {
   emitUpdateNote,
   onLockDenied,
   offLockDenied,
+  onUndoRedoState,
 };


### PR DESCRIPTION
This Pr merges the enable and disable redo/undo button in real time.
## Implementation
- Implemented real time undo/redo state syncing using note_undo_redo_state socket events. 
- On the backend, socket emit updates after note creation, edits, undo, and redo actions. 
- Frontend listens to state updates per note using the undo and redo state. 
- Disabled both undo and redo button upon creation, enabled undo after first edit, enabled redo after undo. 
## Test Plan
- Made a demo to demonstrate enable and disable in real time. 
https://www.loom.com/share/31e1b61f055c4040a33df80fa645ca65?sid=74360ca1-2099-467e-9657-4813e58c8851